### PR TITLE
Bump version after-the-fact

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-shadowenv",
     "displayName": "shadowenv",
     "description": "Automatically detect and load shadowenv when opening VS Code",
-    "version": "0.0.3",
+    "version": "0.1.0",
     "publisher": "Shopify",
     "license": "MIT",
     "engines": {


### PR DESCRIPTION
Cut a release of Version 0.1.0 to publish the changes added in https://github.com/Shopify/vscode-shadowenv/commit/64f19528da32edc0f3a9ba5813e1bdbc1c81bd2e.