### PR TITLE
Fix an error command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ up VS Code.
 In order to run a command press `cmd+shift+p` to view the Command Palette. There type:
 
 * `shadowenv trust` to trust and load the local Shadowenv
-* `shadowenv version` to view the current `shadowenv` version
+* `shadowenv --version` to view the current `shadowenv` version
 
 ## Contribute
 


### PR DESCRIPTION


### WHAT are you trying to accomplish with this PR?
Fix an error command in README.

Tested with `shadowenv 2.0.6`: 

```
➜  Systems git:(master) ✗ shadowenv help
shadowenv 2.0.6

USAGE:
    shadowenv <SUBCOMMAND>

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

SUBCOMMANDS:
    diff     Display a diff of changed environment variables.
    exec     Execute a command after loading the environment from the current directory.
    help     Prints this message or the help of the given subcommand(s)
    hook     Runs the shell hook. You shouldn't need to run this manually.
    init     Prints a script which can be eval'd to set up shadowenv in various shells.
    trust    Mark this directory as 'trusted', allowing shadowenv programs to be run.
➜  Systems git:(master) ✗ shadowenv -V
shadowenv 2.0.6
```

### Checklist

- [ ] I have added this change to our [CHANGELOG](/CHANGELOG.md).
- [x] I have manually verified/tested these changes.
